### PR TITLE
added require to fix loading issue on ubuntu

### DIFF
--- a/lib/shhh/app/commands/command.rb
+++ b/lib/shhh/app/commands/command.rb
@@ -1,3 +1,5 @@
+require 'shhh/app/short_name'
+require 'shhh/app/commands'
 require 'active_support/inflector'
 module Shhh
   module App


### PR DESCRIPTION
backtrace -

The funny thing is, I didn't get this on another ubuntu machine :S

```
vagrant@vagrant-ubuntu-trusty-64:~/workspace/shippo-deploy$ cap -T -t
/home/vagrant/workspace/shippo-deploy/Capfile
** Invoke load:defaults (first_time)
** Execute load:defaults
cap aborted!
NameError: uninitialized constant Shhh::App::ShortName
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/shhh-1.6.4/lib/shhh/app/commands/command.rb:13:in `singleton class'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/shhh-1.6.4/lib/shhh/app/commands/command.rb:10:in `block in inherited'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/shhh-1.6.4/lib/shhh/app/commands/command.rb:9:in `instance_eval'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/shhh-1.6.4/lib/shhh/app/commands/command.rb:9:in `inherited'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/shhh-1.6.4/lib/shhh/app/commands/open_editor.rb:11:in `<module:Commands>'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/shhh-1.6.4/lib/shhh/app/commands/open_editor.rb:10:in `<module:App>'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/shhh-1.6.4/lib/shhh/app/commands/open_editor.rb:9:in `<module:Shhh>'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/shhh-1.6.4/lib/shhh/app/commands/open_editor.rb:8:in `<top (required)>'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/require_dir-0.1.2/lib/require_dir/loader.rb:26:in `require'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/require_dir-0.1.2/lib/require_dir/loader.rb:26:in `block in dir'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/require_dir-0.1.2/lib/require_dir/loader.rb:23:in `glob'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/require_dir-0.1.2/lib/require_dir/loader.rb:23:in `dir'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/require_dir-0.1.2/lib/require_dir/loader.rb:43:in `dir_r'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/shhh-1.6.4/lib/shhh/app.rb:51:in `<top (required)>'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/require_dir-0.1.2/lib/require_dir/loader.rb:26:in `require'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/require_dir-0.1.2/lib/require_dir/loader.rb:26:in `block in dir'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/require_dir-0.1.2/lib/require_dir/loader.rb:23:in `glob'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/require_dir-0.1.2/lib/require_dir/loader.rb:23:in `dir'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/shhh-1.6.4/lib/shhh.rb:109:in `<top (required)>'
/home/vagrant/workspace/shippo-deploy/lib/capistrano/tasks/secrets/edit.cap:1:in `require'
/home/vagrant/workspace/shippo-deploy/lib/capistrano/tasks/secrets/edit.cap:1:in `<top (required)>'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/rake_module.rb:29:in `load'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/rake_module.rb:29:in `load_rakefile'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/default_loader.rb:11:in `load'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:764:in `load_imports'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/capistrano-4e680310f244/lib/capistrano/application.rb:96:in `load_imports'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:694:in `raw_load_rakefile'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:96:in `block in load_rakefile'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:178:in `standard_exception_handling'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:95:in `load_rakefile'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:79:in `block in run'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:178:in `standard_exception_handling'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:77:in `run'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/capistrano-4e680310f244/lib/capistrano/application.rb:14:in `run'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/capistrano-4e680310f244/bin/cap:3:in `<top (required)>'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bin/cap:23:in `load'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bin/cap:23:in `<top (required)>'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `load'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `kernel_load'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:24:in `run'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/cli.rb:304:in `exec'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/cli.rb:11:in `start'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/exe/bundle:27:in `block in <top (required)>'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/friendly_errors.rb:98:in `with_friendly_errors'
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/exe/bundle:19:in `<top (required)>'
/home/vagrant/.rbenv/versions/2.3.1/bin/bundle:23:in `load'
/home/vagrant/.rbenv/versions/2.3.1/bin/bundle:23:in `<main>
```